### PR TITLE
Update FastLED_NeoPixel.cpp

### DIFF
--- a/src/FastLED_NeoPixel.cpp
+++ b/src/FastLED_NeoPixel.cpp
@@ -73,7 +73,7 @@ void FastLED_NeoPixel_Variant::fill(uint32_t c, uint16_t first, uint16_t count) 
 
 	if (first == 0 && count == 0) count = numLEDs;  // if auto, fill from start to end
 	else if (first != 0 && count == 0) count = numLEDs - first;  // if only first is set, fill from first to end
-	else count = min(count, numLEDs - first);  // if both are set, fill from first to end without overrunning buffer
+	else count = _min(count, numLEDs - first);  // if both are set, fill from first to end without overrunning buffer
 
 	fill_solid(leds + first, count, packedToColor(c));
 }


### PR DESCRIPTION
fix compilation errors with esp8266 arduino framework builds. (Can be observed in latest esp8266 core 3.1.2 for esp8266 and older cores as well)