### PR TITLE
Fix min function deduction on ESP platforms

### DIFF
--- a/src/FastLED_NeoPixel.cpp
+++ b/src/FastLED_NeoPixel.cpp
@@ -73,7 +73,7 @@ void FastLED_NeoPixel_Variant::fill(uint32_t c, uint16_t first, uint16_t count) 
 
 	if (first == 0 && count == 0) count = numLEDs;  // if auto, fill from start to end
 	else if (first != 0 && count == 0) count = numLEDs - first;  // if only first is set, fill from first to end
-	else count = min(count, numLEDs - first);  // if both are set, fill from first to end without overrunning buffer
+	else count = min(count, static_cast<uint16_t>(numLEDs - first));  // if both are set, fill from first to end without overrunning buffer
 
 	fill_solid(leds + first, count, packedToColor(c));
 }


### PR DESCRIPTION
Having the calculation as part of the function argument was apparently confusing the template. Casting the result of the uint16 - uint16 math to a uint16 fixes the problem and it can find the template just fine.

This wasn't previously an issue on the AVR platforms because the min function is done using a macro there.

Hopefully fixes #5.