### PR TITLE
Modify FastLED external docs linkage

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -49,14 +49,10 @@ jobs:
           doxygen Doxyfile
 
       - name: Generate FastLED Tag File
-        env:
-          FASTLED_VERSION: 3.1.7  # latest version published on GitHub pages
         run: |
-          git clone --depth 1 --branch ${{ env.FASTLED_VERSION }} https://github.com/FastLED/FastLED docs/libraries/FastLED
-          cd docs/libraries/FastLED
-          doxygen -g
+          git clone https://github.com/FastLED/FastLED docs/libraries/FastLED
+          cd docs/libraries/FastLED/docs
           sed -i -E 's/(GENERATE_TAGFILE\s*=\s*).*/\1 fastled.tag/g' Doxyfile
-          sed -i -E 's/(CASE_SENSE_NAMES\s*=\s*).*/\1 NO/g' Doxyfile
           doxygen Doxyfile
 
       - name: Generate Docs

--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -2438,7 +2438,7 @@ SKIP_FUNCTION_MACROS   = YES
 # run, you must also specify the path to the tagfile here.
 
 TAGFILES               = "libraries/Adafruit_NeoPixel/neopixel.tag = https://adafruit.github.io/Adafruit_NeoPixel/html/" \
-                         "libraries/FastLED/fastled.tag = http://fastled.io/docs/3.1/"
+                         "libraries/FastLED/docs/fastled.tag = http://fastled.io/docs/"
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create a
 # tag file that is based on the input files it reads. See section "Linking to


### PR DESCRIPTION
The FastLED documentation is now updated for 3.6, using a different source folder structure and destination URL. This fixes the links so that the FastLED_NeoPixel library can find the existing Doxyfile and the existing external docs on fastled.io.